### PR TITLE
Update CIP-0137

### DIFF
--- a/CIP-0137/README.md
+++ b/CIP-0137/README.md
@@ -444,7 +444,6 @@ stateDiagram-v2
 | StBusy     | MsgRejectMessage | reason     | StIdle   |
 | StIdle     | MsgDone          |            | StDone   |
 
-
 ##### CDDL Encoding Specification
 
 ```cddl
@@ -500,10 +499,10 @@ The protocol follows a simple request-response pattern:
 
 #### State machine
 
-| Agency            |                |
-| ----------------- | -------------- |
-| Client has Agency | StIdle         |
-| Server has Agency | StBusy, StDone |
+| Agency            |                                          |
+| ----------------- | ---------------------------------------- |
+| Client has Agency | StIdle                                   |
+| Server has Agency | StBusyNonBlocking,StBusyBlocking, StDone |
 
 ```mermaid
 stateDiagram-v2
@@ -556,7 +555,7 @@ localMessageNotificationMessage
   / msgClientDone
   / msgServerDone
 
-msgRequestMessages          = [0, isBlocking, ackedMessages]
+msgRequestMessages          = [0, isBlocking]
 msgReplyMessagesNonBlocking = [1, messages, hasMore]
 msgReplyMessagesBlocking    = [2, messages]
 msgClientDone               = [3]
@@ -579,7 +578,6 @@ message = [
 
 hasMore = false / true
 isBlocking = false / true
-ackedMessages = * messageId
 messages = [* message]
 ```
 
@@ -687,15 +685,15 @@ the KES key.
 
 - [x] Write a "formal" specification of the protocols along with vectors/conformance checker for protocol's structure and state machine logic.
 - [x] Write an architecture document extending this CIP with more technical details about the implementation.
-    - See [here](https://github.com/IntersectMBO/ouroboros-network/wiki/Decentralized-Message-Queue-(DMQ)-Implementation-Overview)
+  - See [here](<https://github.com/IntersectMBO/ouroboros-network/wiki/Decentralized-Message-Queue-(DMQ)-Implementation-Overview>)
 - [x] Validate protocol behaviour with all relevant parties (Network and Node teams).
 - [x] Make the current Cardano Network Diffusion Layer general and reusable so a new, separate Mithril Diffusion Layer can be instantiated.
-    - See [here](https://github.com/IntersectMBO/ouroboros-network/wiki/Reusable-Diffusion-Investigation) and [here](https://github.com/IntersectMBO/ouroboros-network/pull/5016)
+  - See [here](https://github.com/IntersectMBO/ouroboros-network/wiki/Reusable-Diffusion-Investigation) and [here](https://github.com/IntersectMBO/ouroboros-network/pull/5016)
 - [ ] Implement DMQ Node that is able to run general diffusion (i.e. without the mini-protocols).
-    - See [here](https://github.com/IntersectMBO/ouroboros-network/pull/5109)
+  - See [here](https://github.com/IntersectMBO/ouroboros-network/pull/5109)
 - [ ] Implement the n2n and n2c mini-protocols:
-    - [ ] DMQ Node
-    - [ ] Pallas Library (TxPipe)
+  - [ ] DMQ Node
+  - [ ] Pallas Library (TxPipe)
 - [ ] Implement the n2c mini-protocols in Mithril signer and aggregator nodes.
 
 ## References

--- a/CIP-0137/README.md
+++ b/CIP-0137/README.md
@@ -692,9 +692,15 @@ the KES key.
 - [ ] Implement DMQ Node that is able to run general diffusion (i.e. without the mini-protocols).
   - See [here](https://github.com/IntersectMBO/ouroboros-network/pull/5109)
 - [ ] Implement the n2n and n2c mini-protocols:
-  - [ ] DMQ Node
-  - [ ] Pallas Library (TxPipe)
-- [ ] Implement the n2c mini-protocols in Mithril signer and aggregator nodes.
+  - [ ] DMQ Node:
+    - [ ] n2c mini-protocols
+    - [ ] n2n mini-protocols
+  - [ ] Pallas Library (TxPipe):
+    - [x] n2c mini-protocols
+    - [ ] n2n mini-protocols
+- [ ] Implement the n2c mini-protocols in Mithril nodes:
+  - [ ] Mithril signer
+  - [ ] Mithril aggregator
 
 ## References
 


### PR DESCRIPTION
This pull request updates the `CIP-0137/README.md` file to refine the protocol documentation, improve clarity, and adjust the state machine definitions. The changes include updates to the state machine table, modifications to message definitions, removal of unused fields, and adjustments to the protocol implementation checklist.

### State Machine Updates:
* Refined the state machine agency table to include new states: `StBusyNonBlocking` and `StBusyBlocking`. This provides a clearer distinction between blocking and non-blocking server states.

### Message Definitions:
* Removed the `ackedMessages` field from `msgRequestMessages` to simplify the message structure.
* Updated the message definitions to remove the `ackedMessages` field from the protocol's encoding specification.

### Documentation Improvements:
* Fixed a broken link in the protocol implementation checklist by converting the URL to Markdown-compatible syntax.