### PR TITLE
Leios: announced_eb_size is size of the txs rather than of their references

### DIFF
--- a/CIP-????/README.md
+++ b/CIP-????/README.md
@@ -645,9 +645,8 @@ RBs are Praos blocks extended to support Leios by optionally announcing EBs in
 their headers and embedding EB certificates in their bodies.
 
 1. **Header additions**:
-
    - `announced_eb` (optional): Hash of the EB created by this block producer
-   - `announced_eb_size` (optional): Size in bytes of the announced EB (4 bytes)
+   - `announced_eb_size` (optional): Size in bytes of the announced EB's referenced transactions (4 bytes)
    - `certified_eb` (optional): Single bit indicating whether this RB certifies
      the EB announced by the previous RB (the EB hash is already available via
      the previous header's `announced_eb` field)
@@ -1258,7 +1257,7 @@ over time.
 | ------- | ------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | Client→ | MsgLeiosNotificationRequestNext | $\emptyset$                                                  | Requests one Leios notifications, the announcement of an EB or delivery offers for blocks, transactions, and votes.                                                                                                                   |
 | ←Server | MsgLeiosBlockAnnouncement       | RB header that announces an EB                               | The server has seen this EB announcement.                                                                                                                                                                                             |
-| ←Server | MsgLeiosBlockOffer              | slot and Leios hash                                          | The server can immediately deliver this block.                                                                                                                                                                                        |
+| ←Server | MsgLeiosBlockOffer              | slot, Leios hash, and byte size                              | The server can immediately deliver this block, which has the given byte size.                                                                                                                                                         |
 | ←Server | MsgLeiosBlockTxsOffer           | slot and Leios hash                                          | The server can immediately deliver any transaction referenced by this block.                                                                                                                                                          |
 | ←Server | MsgLeiosVotesOffer              | list of slot and vote-issuer-id pairs                        | The server can immediately deliver votes with these identifiers.                                                                                                                                                                      |
 | Client→ | MsgLeiosBlockRequest            | slot and Leios hash                                          | The server must now deliver this block.                                                                                                                                                                                               |
@@ -1268,8 +1267,8 @@ over time.
 | Client→ | MsgLeiosVotesRequest            | list of slot and vote-issuer-id                              | The server must now deliver these votes.                                                                                                                                                                                              |
 | ←Server | MsgLeiosVoteDelivery            | list of votes                                                | The votes from an earlier MsgLeiosVotesRequest.                                                                                                                                                                                       |
 | Client→ | MsgLeiosBlockRangeRequest       | two slots and two RB header hashes                           | The server must now deliver the EBs certified by the given range of RBs, in order.                                                                                                                                                    |
-| ←Server | MsgLeiosNextBlockAndTxsInRange  | an EB and all of its transactions                            | The next certified block from an earlier MsgLeiosBlockRangeRequest.                                                                                                                                                                   |
-| ←Server | MsgLeiosLastBlockAndTxsInRange  | an EB and all of its transactions                            | The last certified block from an earlier MsgLeiosBlockRangeRequest.                                                                                                                                                                   |
+| ←Server | MsgLeiosNextBlockAndTxsInRange  | list of transactions                                         | The list of all transactions referenced by the next certified EB from an earlier MsgLeiosBlockRangeRequest.                                                                                                                           |
+| ←Server | MsgLeiosLastBlockAndTxsInRange  | list of transactions                                         | The list of all transactions referenced by the last certified EB from an earlier MsgLeiosBlockRangeRequest.                                                                                                                           |
 
 <em>Table 4: Leios Information Exchange Requirements table (IER table)</em>
 


### PR DESCRIPTION
For this to be true ...

> The `certified_eb` bit enables syncing nodes to predict the total size of valid responses to their requests for batches of EBs certified on the historical chain.

... the `announced_eb_size` field needs to be the size of the txs, not the size of the tx references. Syncing nodes need to download all of the txs --- there's no reason they'd already have a subset of them. And they can reconstruct the tx references from the list of txs they receive.

The MsgLeiosBlockOffer does claim a byte size for the list of references, and the peer can disconnect if the peer sends an EB body with a different size.

---

This resulting scheme is a natural match for the fact that the reason an EB body contains references to txs instead of the txs themselves is merely an optimization.