### PR TITLE
doc(CIP-0164): node-to-client changes

### DIFF
--- a/CIP-0164/README.md
+++ b/CIP-0164/README.md
@@ -80,6 +80,7 @@ technical resources, visit the Leios Innovation R&D site at
   - [Incentives](#incentives)
     - [Adaptive EB production](#adaptive-eb-production)
     - [Hardware upgrade](#hardware-upgrade)
+  - [Clients](#clients)
 - [Rationale: how does this CIP achieve its goals?](#rationale-how-does-this-cip-achieve-its-goals)
   - [How Leios addresses CPS-18](#how-leios-addresses-cps-18)
   - [Evidence](#evidence)
@@ -1452,6 +1453,21 @@ demonstrated in the [operating costs analysis](#operating-costs), SPO
 profitability improves significantly once sustained throughput exceeds 30-50
 TPS, providing clear economic incentives for infrastructure upgrades.
 
+### Clients
+
+Changes proposed for Ouroboros Leios will require changes to the node-to-client
+(N2C) mini-protocols used by client applications throughout the ecosystem.
+Concrete decisions will likely naturally surface through various
+implementations, however some care should be taken to minimize ecosystem
+disruption.
+
+An [Impact Analysis][impact-analysis] has been done and continued discussion
+is necessary. One recommendation is to serve a modified block with "inline"
+EB transactions over LocalChainSync. Additional queries and ledger state may
+be extended to provide Leios specific information to applications. It is
+assumed nodes providing client interfaces will provide the modified block
+to clients.
+
 ## Rationale: how does this CIP achieve its goals?
 
 Ouroboros Leios introduces a committee-based voting layer over Nakamoto-style
@@ -2515,6 +2531,7 @@ usual mechanisms of governing a hard-fork will be employed.
 - **Threat model** — [Report #1][threat-model]
 - **Leios attack surface** — [Report #2][threat-model-report2]
 - **Node operating costs** — [Cost estimate][cost-estimate]
+- **Impact analysis** - [Impact][impact-analysis]
 
 **Related**
 
@@ -2596,6 +2613,9 @@ usual mechanisms of governing a hard-fork will be employed.
 [cost-estimate]:
   https://github.com/input-output-hk/ouroboros-leios/blob/d5f1a9bc940e69f406c3e25c0d7d9aa58cf701f8/docs/cost-estimate/README.md
   "Leios node operating costs"
+[impact-analysis]:
+  https://github.com/input-output-hk/ouroboros-leios/blob/4603cfd0b545cccf3d7c8fddc75e6e0f182f132a/docs/ImpactAnalysis.md
+  "Impact Analysis"
 
 <!-- Other protocol references -->
 

--- a/CIP-0164/README.md
+++ b/CIP-0164/README.md
@@ -1468,6 +1468,9 @@ be extended to provide Leios specific information to applications. It is
 assumed nodes providing client interfaces will provide the modified block
 to clients.
 
+A [CDDL for merged blocks](#merged-block-cddl) is available in Appendix B.
+
+
 ## Rationale: how does this CIP achieve its goals?
 
 Ouroboros Leios introduces a committee-based voting layer over Nakamoto-style
@@ -2788,6 +2791,45 @@ tx_reference =
   [ tx_hash                  : hash32     ; Hash of complete transaction bytes
   , tx_size                  : uint16     ; Transaction size in bytes
   ]
+```
+
+<a id="merged-block-cddl" href="#merged-block-cddl">**Merged Block**</a>
+
+```diff
++ merged_block =
++   [ header                   : block_header
++   , transaction_bodies       : [* transaction_body]
++   , transaction_witness_sets : [* transaction_witness_set]
++   , auxiliary_data_set       : {* transaction_index => auxiliary_data}
++   , ? eb_certificate         : leios_certificate
++   , ? eb_tx_references       : [* tx_reference]
++   ]
+
++ block_header =
++   [ header_body              : block_header_body
++   , body_signature           : kes_signature
++   ]
+
++ block_header_body =
++   [ block_number             : uint
++   , slot                     : slot_no
++   , prev_hash                : hash32
++   , issuer_vkey              : vkey
++   , vrf_vkey                 : vrf_vkey
++   , vrf_result               : vrf_cert
++   , block_body_size          : uint
++   , block_body_hash          : hash32
++   , ? ( announced_eb         : hash32
++       , announced_eb_size    : uint32
++       )
++   , ? certified_eb           : bool
++   ]
+
++ ; Reference structures
++ tx_reference =
++  [ tx_hash                  : hash32     ; Hash of complete transaction bytes
++  , tx_size                  : uint16     ; Transaction size in bytes
++  ]
 ```
 
 <a id="votes-certificates-cddl" href="#votes-certificates-cddl">**Votes and


### PR DESCRIPTION
A goal of using Linear Leios is to reduce downstream impact. Linking the ouroboros-leios impact analysis and adding an assumption that the requirements therein are being followed by nodes serving client interfaces. This should require minimal changes on the clients without having to adopt new mini-protocols as many are LocalChainSync only.