### PR TITLE
Add key registration, rotation, and fix vote specification

### DIFF
--- a/CIP-0164/README.md
+++ b/CIP-0164/README.md
@@ -809,10 +809,15 @@ the initial stake snapshots.
 Structure**: The voting committee for an epoch is determined by **stake-based
 truncation** of the active stake distribution. At the epoch boundary, pools
 are ordered by stake in descending order and selected, in order, until the
-cumulative selected stake reaches a target threshold (or, equivalently, until
-the truncation error falls below a target maximum). The resulting committee
+cumulative selected stake reaches a target coverage. The resulting committee
 is fixed for the entire epoch; every committee member is eligible to vote on
 every EB produced within that epoch.
+
+> [!WARNING]
+>
+> TODO: the stake-based committee scheme is resilient to under-representation
+> because each vote's weight is known. That means we don't need to trade-off
+> anything here and could go with a fixed committee size!
 
 The committee is configured by a *cumulative-stake* (or *maximum-error*)
 protocol parameter, not by a fixed committee count. The realized committee
@@ -824,39 +829,32 @@ realized committee grows beyond what is optimal for voting throughput, that
 cost is paid on the optimistic (certifying) path of the protocol and is
 acceptable. Under-representation is the case the parameter is tuned against.
 
-There is no per-EB sortition. There are no non-persistent voters. Membership is
-determined once per epoch, deterministically, from the stake distribution
-available at the epoch boundary; this matches the cadence of the existing
-VRF-key handling for pool parameters. The rationale for selecting this scheme
-over the alternatives considered (notably wFA^LS) is recorded in [Design
-Decisions](#voting-committee-selection).
+The rationale for selecting this scheme over the alternatives considered
+(notably wFA^LS) is recorded in [Design Decisions](#voting-committee-selection).
 
 The certificate accordingly consists of a bitfield indicating which committee
 members signed plus a single aggregated BLS signature. Its size grows linearly
 in committee size, dominated by the bitfield ($\lceil N/8 \rceil$ bytes) plus
 a fixed signature and overhead.
 
-<a id="vote-structure" href="#vote-structure"></a>**Vote Structure**: All votes
-include the `endorser_block_hash` field that uniquely identifies the target EB:
+<a id="vote-structure" href="#vote-structure"></a>**Vote Structure**: Votes are
+cast on EB announcements, which uniquely identifies an EB extending a
+Praos chain and have the following structure:
 
-Under the stake-based committee scheme, all votes share a single uniform
-structure:
-
-- `slot_no`: Identifier for the voting round and equal to slot number of the RB
-  that announced the target EB.
-- `endorser_block_hash`: Hash of the EB to vote on.
+- `announcing_rb_hash`: Announcement to vote on; a hash of the RB header
+  pointing to an EB via `announced_eb`.
 - `voter_id`: Index into the epoch's stake-based committee (pools ordered by
   descending stake at the epoch boundary; see [Committee
   Selection](#committee-selection))
-- `vote_signature`: BLS signature over `concat(slot_no, endorser_block_hash)`
+- `vote_signature`: BLS signature over `announcing_rb_hash`
 
-Votes do not carry per-EB sortition eligibility proofs. Eligibility is
-determined by epoch-level committee membership and verified by direct lookup
-against the committee derived at the epoch boundary.
+Votes do not carry eligibility proofs. Eligibility is determined by epoch-level
+committee membership and verified by direct lookup against the committee derived
+at the epoch boundary.
 
-Binding the vote signature to `slot_no` in addition to `endorser_block_hash`
-ensures voters validated the EB against the same ledger state it extends when
-certified on chain; recall that multiple RB headers could announce the same EB.
+Binding the vote to `announcing_rb_hash` ensures voters validated the EB against
+the same ledger state it extends when certified on chain; recall that multiple
+RB headers could announce the same EB.
 
 A [CDDL for votes and certificates](#votes-certificates-cddl) is available in
 Appendix B.

--- a/CIP-0164/README.md
+++ b/CIP-0164/README.md
@@ -754,6 +754,57 @@ voting scheme alongside their existing VRF and KES keys. In the BLS
 implementation described here, this would be a BLS key over the BLS12-381
 elliptic curve.
 
+<a id="key-registration" href="#key-registration"></a>**Key Registration and
+Rotation**: The proposed mechanism is to extend the existing stake pool
+registration certificate to carry the voting key, rather than introduce a
+dedicated certificate or place the key in the block header. Extending the pool
+registration certificate binds the voting key's lifecycle to the pool's —
+registered, re-registered, and retired together — and reuses the authorization
+already required to register a pool, adding no new certificate type or
+witnessing rule. A dedicated certificate would also work but adds a new type
+and lifecycle to specify and maintain; a header-carried key (analogous to the
+VRF key and signed by the KES key) was likewise considered and would let the
+key ride the operational-certificate path, at the cost of requiring the ledger
+to observe block headers.
+
+The registered key material is a public key together with a proof of
+possession. In the BLS instantiation this is `bls_key = [bls_pubkey: G2 (96
+bytes), bls_possessionproof: G1 (48 bytes)]`. The proof of possession is
+mandatory and verified at registration: BLS aggregate signatures are otherwise
+vulnerable to rogue-key attacks, in which an adversary registers a key crafted
+relative to others' keys so that an aggregate appears to include voters who
+never signed. Only a key with a valid proof of possession may occupy a
+committee seat or contribute to a certificate. Because committee membership is
+stake-based (see [Committee Structure](#committee-structure)), a pool may be
+selected by stake without having registered a valid voting key; such a seat is
+*keyless* — it cannot sign, and any certificate marking a keyless seat as a
+signer must be rejected.
+
+Voting keys **rotate** on a cadence comparable to KES *key rotation* (~90 days
+on Cardano mainnet), which a corresponding key time-to-live should enforce.
+This is distinct from KES *key evolution* (~12 hours): evolution provides
+forward secrecy within a single key's lifetime and is not required for voting
+keys. Unlike a KES key, which takes effect immediately on the chain it is used
+to build, a voting key must be **activated at an epoch boundary**, because the
+committee is fixed once per epoch from the stake distribution — so a voting
+key's activation resembles that of a VRF key.
+
+A voting key could in principle activate sooner than a VRF key: VRF keys are
+held back to prevent grinding of the leader-election nonce, a concern voting
+keys do not share, so a registered voting key could become active as soon as
+the stake snapshot it appears in stabilizes. The recommended design nonetheless
+**aligns voting-key activation with VRF-key rotation**. Activation is not merely
+an on-chain event — an operator must install the newly-active key on the hot,
+block-producing machine for the epoch in which it becomes effective — so a
+staggered schedule would force an operator who rotates both keys in one epoch to
+perform two separate hot-key swaps in consecutive epochs. Aligning the two
+schedules collapses this into a single swap, trading a slightly longer window in
+which the new key is registered but not yet active for materially simpler key
+handling. A newly registered or rotated key is not eligible to vote until the
+snapshot in which it appears becomes active; a committee that must be live from
+the first epoch (e.g. at genesis) therefore requires its keys to be present in
+the initial stake snapshots.
+
 <a id="committee-structure" href="#committee-structure"></a>**Committee
 Structure**: The voting committee for an epoch is determined by **stake-based
 truncation** of the active stake distribution. At the epoch boundary, pools
@@ -2640,12 +2691,12 @@ stake data.)
   future revisitation if simulation or operational data warrant it.
 
 The adaptive-security argument above is contingent on BLS key rotation
-(Appendix A requirement 2). The on-chain mechanism for registering rotations
-— likely an extension of the existing pool-registration certificate path with
-epoch-boundary activation — is left to a follow-up PR amending this CIP.
-Until that mechanism is specified, the static-vs-adaptive distinction
-collapses for *all* schemes considered here (stake-based truncation, wFA^LS,
-and All-vote alike), so the relative comparison above is unaffected.
+(Appendix A requirement 2). The on-chain mechanism — extending the pool
+registration certificate to carry the voting key, with epoch-boundary
+activation aligned to VRF-key rotation — is specified under [Key Registration
+and Rotation](#key-registration). The static-vs-adaptive distinction applies
+equally to *all* schemes considered here (stake-based truncation, wFA^LS, and
+All-vote alike), so the relative comparison above is unaffected.
 
 **wFA^IID as a forward-looking option.** A variant **wFA^IID** (Fait Accompli
 with IID stake-proportional sampling for non-persistent seats) is recorded here

--- a/CIP-0164/README.md
+++ b/CIP-0164/README.md
@@ -767,14 +767,14 @@ VRF key and signed by the KES key) was likewise considered and would let the
 key ride the operational-certificate path, at the cost of requiring the ledger
 to observe block headers.
 
-The registered key material is a public key together with a proof of
-possession. In the BLS instantiation this is `bls_key = [bls_pubkey: G2 (96
-bytes), bls_possessionproof: G1 (48 bytes)]`. The proof of possession is
-mandatory and verified at registration: BLS aggregate signatures are otherwise
-vulnerable to rogue-key attacks, in which an adversary registers a key crafted
-relative to others' keys so that an aggregate appears to include voters who
-never signed. Only a key with a valid proof of possession may occupy a
-committee seat or contribute to a certificate. Because committee membership is
+The registered key material is a public key together with a proof of possession
+carried in an optional `bls_key` field of the pool registration certificate (see
+[Pool Registration](#pool-registration-cddl) in Appendix B). The proof of
+possession is mandatory and verified at registration: BLS aggregate signatures
+are otherwise vulnerable to rogue-key attacks, in which an adversary registers a
+key crafted relative to others' keys so that an aggregate appears to include
+voters who never signed. Only a key with a valid proof of possession may occupy
+a committee seat or contribute to a certificate. Because committee membership is
 stake-based (see [Committee Structure](#committee-structure)), a pool may be
 selected by stake without having registered a valid voting key; such a seat is
 *keyless* — it cannot sign, and any certificate marking a keyless seat as a
@@ -3252,7 +3252,39 @@ wire at vote time.
 ; BLS12-381 MinSig encodings for Leios
 leios_bls_verification_key = bytes .size 96
 leios_bls_signature        = bytes .size 48
-leios_bls_pop              = bytes .size 96
+leios_bls_pop              = bytes .size 48
+```
+
+<a id="pool-registration-cddl" href="#pool-registration-cddl">**Pool
+Registration**</a>
+
+Registering a voting key extends the existing stake pool registration
+certificate with an optional `bls_key` field that may also be `nil` (for
+backwards compatibility). A pool that has not registered a voting key occupies a
+*keyless* committee seat (see [Key Registration and
+Rotation](#key-registration)):
+
+
+```diff
+ pool_registration_cert = (3, pool_params)
+
+ pool_params =
+   (   operator       : pool_keyhash
+   ,   vrf_keyhash    : vrf_keyhash
++  , ? bls_key        : bls_key/ nil
+   ,   pledge         : coin
+   ,   cost           : coin
+   ,   margin         : unit_interval
+   ,   reward_account : reward_account
+   ,   pool_owners    : set<addr_keyhash>
+   ,   relays         : [* relay]
+   ,   pool_metadata  : pool_metadata/ nil
+   )
+
++bls_key =
++  [ leios_bls_verification_key
++  , leios_bls_pop
++  ]
 ```
 
 ## Copyright


### PR DESCRIPTION
Represents the latest findings and changes we made when implementing the BLS key registration, rotation and committee selection scheme in the `cardano-node`.

See also https://github.com/input-output-hk/ouroboros-leios/issues/1010, https://github.com/input-output-hk/ouroboros-leios/issues/1024, https://github.com/input-output-hk/ouroboros-leios/issues/941

Done as a small PR onto our fork, before upstreaming an aggregate PR onto the cardano-foundation/CIPs